### PR TITLE
Bump version to v0.2.2

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -86,7 +86,7 @@
     "price": "0",
     "priceCurrency": "USD"
   },
-  "softwareVersion": "0.2.1",
+  "softwareVersion": "0.2.2",
   "author": {
     "@type": "Organization",
     "name": "WCNegentropy",

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -71,7 +71,7 @@ layout: default
       <div class="flex items-start justify-between mb-4">
         <span class="text-5xl">⚡</span>
         <div class="flex items-center gap-2">
-          <span class="text-xs font-mono bg-green-100 dark:bg-green-900/50 text-green-700 dark:text-green-300 px-3 py-1.5 rounded">v0.2.1 • LIVE</span>
+          <span class="text-xs font-mono bg-green-100 dark:bg-green-900/50 text-green-700 dark:text-green-300 px-3 py-1.5 rounded">v0.2.2 • LIVE</span>
           <span class="text-xs font-mono bg-purple-100 dark:bg-purple-900/50 text-purple-700 dark:text-purple-300 px-3 py-1.5 rounded">MIT</span>
         </div>
       </div>
@@ -122,7 +122,7 @@ layout: default
            class="inline-flex items-center gap-2 rounded-xl border border-brand-300 dark:border-slate-700 px-5 py-3 font-semibold hover:shadow-glow transition-all duration-300">
           📦 NPM Package →
         </a>
-        <a href="https://github.com/WCNegentropy/retro-vibecoder/releases/tag/0.2.1"
+        <a href="https://github.com/WCNegentropy/retro-vibecoder/releases/tag/0.2.2"
            target="_blank"
            rel="noopener noreferrer"
            class="inline-flex items-center gap-2 rounded-xl border border-brand-300 dark:border-slate-700 px-5 py-3 font-semibold hover:shadow-glow transition-all duration-300">


### PR DESCRIPTION
## Summary
This PR updates the project version from v0.2.1 to v0.2.2 across all relevant files.

## Key Changes
- Updated version badge in home layout from v0.2.1 to v0.2.2
- Updated GitHub release link to point to the v0.2.2 release tag
- Updated software version in schema metadata from v0.2.1 to v0.2.2

## Details
The version bump is reflected in:
- Homepage display badge (`_layouts/home.html`)
- Release download link (`_layouts/home.html`)
- Schema.org structured data for software version (`_includes/head.html`)

This ensures consistency across the website and documentation for the v0.2.2 release.

https://claude.ai/code/session_01JFWNoHMhvb9hj8Y6eFt7H5